### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -441,7 +441,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -692,7 +692,7 @@
     <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>
     <commons-pool.version>1.5.6</commons-pool.version>
     <validation-api.version>1.0.0.GA</validation-api.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <hibernate-validator.version>4.3.1.Final</hibernate-validator.version>
     <java.version>1.7</java.version>
     <poi.version>3.7</poi.version>


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/